### PR TITLE
Alternative HTTPError approach and handling for mutable default dicts in _request function

### DIFF
--- a/powerschool/client.py
+++ b/powerschool/client.py
@@ -64,27 +64,19 @@ class PowerSchool:
         self.metadata = self.PluginMetadata(self.get_plugin_metadata())
         return True
 
-    def _request(self, method, path, params={}, data={}):
+    def _request(self, method, path, params=None, data=None):
         """"""
+        if data is None:
+            data = {}
+        if params is None:
+            params = {}
         url = f"{self.base_url}/{path}"
         response = self.session.request(method, url=url, params=params, json=data)
         try:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as xc:
-            try:
-                error_json = response.json()
-                error_msg = error_json.get("message")
-                errors = error_json.get("errors")
-                errors_str = [
-                    f"\t{er.get('resource')}: {er.get('field')} - {er.get('code')}\n"
-                    for er in errors
-                ]
-                xc_msg = f"{error_msg}\n{errors_str}"
-                raise xc(xc_msg)
-            except:
-                pass
-            raise xc
+            raise SystemExit(xc.response.text)
 
     def get_plugin_metadata(self):
         """


### PR DESCRIPTION
- default handling for mutable dict objects in `_request` function. The prior way works, but it's my understanding that more explicit handling is less of a bug magnet.
- Using the `Response.text `of `HTTPError` in the `_request` function aligns more closely with the error handling paradigm used elsewhere in the `PowerSchool` class (e.g. `InvalidClientError` and `TokenExpiredError`)